### PR TITLE
change Testnetwork form Alfajores to Celo Sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ GAIA_API_KEY=your_gaia_api_key
 
 Before deploying your token, you'll need some test tokens:
 
-1. Visit the [Celo Faucet](https://faucet.celo.org/alfajores)
+1. Visit the [Celo Sepolia Faucet](https://faucet.celo.org/celo-sepolia)
 2. Connect your wallet or paste your account address
 3. Click to receive:
-   - A-CELO (for gas fees)
+   - S-CELO (for gas fees)
    - cUSD (optional)
 
 The faucet will send you test tokens that you can use for deployment.
@@ -58,7 +58,7 @@ const kit = newKitFromWeb3(web3);
 // Add your account
 kit.addAccount(privateKey);
 
-// Deploy using A-CELO for gas
+// Deploy using S-CELO for gas
 const tx = await deploy.send({
     from: defaultAccount,
     gas
@@ -107,7 +107,7 @@ The project uses three main components:
 3. **Smart Contract**
    - Standard ERC20 implementation
    - Built with OpenZeppelin for security
-   - Deployable to Celo's Alfajores testnet
+   - Deployable to Celo's Sepolia testnet
 
 ### Example Responses
 
@@ -116,7 +116,7 @@ AI generated token: { name: "Satoshi's Catnip", symbol: 'SCP' }
 Reading artifacts from: /Users/shk/experiments/onchainkit-gaia/artifacts/contracts/MemeToken.sol/MemeToken.json
 Deploying from account: 0xbDe71618Ef4Da437b0406DA72C16E80b08d6cD45
 Account balance:
-A-CELO: 10.353296994614 A-CELO
+S-CELO: 10.353296994614 S-CELO
 Sending deployment transaction...
 Transaction sent! Hash: 0xd5b17d8ce38ddf50ca7366cf658b3d24d6d9a1d0e3bce6e50b870bd50e961792
 Deployment confirmed in block: 35794429
@@ -126,7 +126,7 @@ Token deployed successfully!
   symbol: 'SCP',
   address: '0x0563109c80733Ea484F86b653262ecA50b8a06d6',
   transactionHash: '0xd5b17d8ce38ddf50ca7366cf658b3d24d6d9a1d0e3bce6e50b870bd50e961792',
-  explorer: 'https://alfajores.celoscan.io/address/0x0563109c80733Ea484F86b653262ecA50b8a06d6'
+  explorer: 'https://celo-sepolia.blockscout.com/address/0x0563109c80733Ea484F86b653262ecA50b8a06d6'
 }
 ```
 
@@ -135,7 +135,7 @@ AI generated token: { name: 'LolToken', symbol: 'LOL' }
 Reading artifacts from: /Users/shk/experiments/onchainkit-gaia/artifacts/contracts/MemeToken.sol/MemeToken.json
 Deploying from account: 0xbDe71618Ef4Da437b0406DA72C16E80b08d6cD45
 Account balance:
-A-CELO: 10.337778442114 A-CELO
+S-CELO: 10.337778442114 S-CELO
 Sending deployment transaction...
 Transaction sent! Hash: 0xfe83c066173362374b1c6a420c2fdc37f7fd4f923bd3d8a3b94e384988cbde13
 Deployment confirmed in block: 35797227
@@ -145,7 +145,7 @@ Token deployed successfully!
   symbol: 'LOL',
   address: '0x47442330f26B58D7C1b7D13ed20fE1244aE58Dbe',
   transactionHash: '0xfe83c066173362374b1c6a420c2fdc37f7fd4f923bd3d8a3b94e384988cbde13',
-  explorer: 'https://alfajores.celoscan.io/address/0x47442330f26B58D7C1b7D13ed20fE1244aE58Dbe'
+  explorer: 'https://celo-sepolia.blockscout.com/address/0x47442330f26B58D7C1b7D13ed20fE1244aE58Dbe'
 }
 ```
 

--- a/deploy.js
+++ b/deploy.js
@@ -10,10 +10,10 @@ async function main() {
         const { name, symbol } = await generateTokenName();
         const { initialSupply } = generateTokenomics();
 
-        // Initialize deployer with Celo Alfajores testnet
+        // Initialize deployer with Celo Sepolia testnet
         const deployer = new TokenDeployer(
             process.env.PRIVATE_KEY,
-            'https://alfajores-forno.celo-testnet.org'
+            'https://forno.celo-sepolia.celo-testnet.org/'
         );
 
         // Deploy token

--- a/hardhat.config.cjs
+++ b/hardhat.config.cjs
@@ -14,10 +14,10 @@ module.exports = {
     }
   },
   networks: {
-    alfajores: {
-      url: "https://alfajores-forno.celo-testnet.org",
+    celoSepolia: {
+      url: "https://forno.celo-sepolia.celo-testnet.org/",
       accounts: [PRIVATE_KEY],
-      chainId: 44787
+      chainId: 11142220
     }
   }
 };

--- a/tokenDeployer.js
+++ b/tokenDeployer.js
@@ -34,10 +34,10 @@ export class TokenDeployer {
         const celoBalance = await goldtoken.balanceOf(address);
         
         console.log('Account balance:');
-        console.log(`A-CELO: ${this.kit.web3.utils.fromWei(celoBalance.toString())} A-CELO`);
+        console.log(`S-CELO: ${this.kit.web3.utils.fromWei(celoBalance.toString())} S-CELO`);
         
         if (celoBalance.isZero()) {
-            throw new Error('Insufficient A-CELO. Please visit https://faucet.celo.org/alfajores to get test tokens');
+            throw new Error('Insufficient S-CELO. Please visit https://faucet.celo.org/celo-sepolia to get test tokens');
         }
     }
 
@@ -93,7 +93,7 @@ export class TokenDeployer {
                 symbol,
                 address: tx.address,
                 transactionHash: tx.transactionHash,
-                explorer: `https://alfajores.celoscan.io/address/${tx.address}`
+                explorer: `https://celo-sepolia.blockscout.com/${tx.address}`
             });
 
             return tx;


### PR DESCRIPTION
On the 30th of September Alfajores will be sunset, aligned with Holeskey. The new testnet Celo Sepolia was launched on the 14th of August. 